### PR TITLE
Add disclaimer for Prysm README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Casper consensus engine based on [Prysm](https://github.com/prysmaticlabs/prysm), to work in concert with the [LUKSO orchestrator](https://github.com/lukso-network/lukso-orchestrator).
 
+## Prysm README
+
 [![Build status](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=master)](https://buildkite.com/prysmatic-labs/prysm)
 [![Go Report Card](https://goreportcard.com/badge/github.com/prysmaticlabs/prysm)](https://goreportcard.com/report/github.com/prysmaticlabs/prysm)
 [![ETH2.0_Spec_Version 1.0.0](https://img.shields.io/badge/ETH2.0%20Spec%20Version-v1.0.0-blue.svg)](https://github.com/ethereum/eth2.0-specs/tree/v1.0.0)


### PR DESCRIPTION
Looking at this fork makes it unclear to the layperson, the readme implies that the staking/validator info, other links etc relate to LUKSO. Saw multiple comments in the community.

>Suggest adding a disclaimer or heading to make this more clear.

>The PR info/guideline is also all relating to Prysm/Eth2.0.