### PR TITLE
Feature: 21 orchestrator rpc client for blocks confirmation flow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 jobs:
 

--- a/beacon-chain/orchestrator/BUILD.bazel
+++ b/beacon-chain/orchestrator/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_library(
+    name = "orchestrator",
+    srcs = [
+            "client.go",
+            "log.go",
+            "types.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/beacon-chain/orchestrator",
+    visibility = ["//beacon-chain:__subpackages__"],
+    deps = [
+        "@com_github_ethereum_go_ethereum//rpc:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_rs_cors//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "orchestrator_test",
+    srcs = [
+            "client_test.go",
+    ],
+    embed = [":orchestrator"],
+    deps = [
+    ],
+)

--- a/beacon-chain/orchestrator/BUILD.bazel
+++ b/beacon-chain/orchestrator/BUILD.bazel
@@ -25,5 +25,6 @@ go_test(
     ],
     embed = [":orchestrator"],
     deps = [
+        "//shared/testutil/assert:go_default_library",
     ],
 )

--- a/beacon-chain/orchestrator/BUILD.bazel
+++ b/beacon-chain/orchestrator/BUILD.bazel
@@ -11,10 +11,12 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/orchestrator",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_rs_cors//:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
     ],
 )
 

--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -1,0 +1,57 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const confirmVanBlockHashesMethod = "orc_confirmVanBlockHashes"
+
+type Client interface {
+	Dial(string) (*Client, error)
+	DialContext(context.Context, string) (*Client, error)
+	NewClient(*rpc.Client) *Client
+	Close()
+	ConfirmVanBlockHashes(context.Context, []*BlockHash) ([]*BlockStatus, error)
+}
+
+// RPCClient defines typed wrappers for the Ethereum RPC API.
+type RPCClient struct {
+	client *rpc.Client
+}
+
+// Dial connects a client to the given URL.
+func Dial(rawurl string) (*RPCClient, error) {
+	return DialContext(context.Background(), rawurl)
+}
+
+func DialContext(ctx context.Context, rawurl string) (*RPCClient, error) {
+	c, err := rpc.DialContext(ctx, rawurl)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c), nil
+}
+
+// NewClient creates a client that uses the given RPC client.
+func NewClient(c *rpc.Client) *RPCClient {
+	return &RPCClient{c}
+}
+
+func (orcRpc *RPCClient) Close() {
+	orcRpc.client.Close()
+}
+
+func (orcRpc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*BlockHash) ([]*BlockStatus, error) {
+	var blockStatuses []*BlockStatus
+
+	err := orcRpc.client.CallContext(ctx, blockStatuses, confirmVanBlockHashesMethod, blockHashes)
+	if err != nil {
+		log.WithField("context", "ConfirmVanBlockHashes").
+			WithField("requestedBlockHashed", blockHashes)
+		return nil, fmt.Errorf("rpcClient call context error, error is: %s", err.Error())
+	}
+
+	return blockStatuses, nil
+}

--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -24,8 +24,8 @@ type RPCClient struct {
 }
 
 // Dial connects a client to the given URL.
-func Dial(ctx context.Context, rawUrl string) (*RPCClient, error) {
-	return DialContext(ctx, rawUrl)
+func Dial(rawUrl string) (*RPCClient, error) {
+	return DialContext(context.Background(), rawUrl)
 }
 
 func DialContext(ctx context.Context, rawUrl string) (*RPCClient, error) {
@@ -33,6 +33,12 @@ func DialContext(ctx context.Context, rawUrl string) (*RPCClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewClient(c), nil
+}
+
+func DialInProc(server *rpc.Server) (*RPCClient, error) {
+	c := rpc.DialInProc(server)
+
 	return NewClient(c), nil
 }
 

--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -46,7 +46,7 @@ func (orcRpc *RPCClient) Close() {
 func (orcRpc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*BlockHash) ([]*BlockStatus, error) {
 	var blockStatuses []*BlockStatus
 
-	err := orcRpc.client.CallContext(ctx, blockStatuses, confirmVanBlockHashesMethod, blockHashes)
+	err := orcRpc.client.CallContext(ctx, &blockStatuses, confirmVanBlockHashesMethod, blockHashes)
 	if err != nil {
 		log.WithField("context", "ConfirmVanBlockHashes").
 			WithField("requestedBlockHashed", blockHashes)

--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -24,12 +24,12 @@ type RPCClient struct {
 }
 
 // Dial connects a client to the given URL.
-func Dial(rawurl string) (*RPCClient, error) {
-	return DialContext(context.Background(), rawurl)
+func Dial(ctx context.Context, rawUrl string) (*RPCClient, error) {
+	return DialContext(ctx, rawUrl)
 }
 
-func DialContext(ctx context.Context, rawurl string) (*RPCClient, error) {
-	c, err := rpc.DialContext(ctx, rawurl)
+func DialContext(ctx context.Context, rawUrl string) (*RPCClient, error) {
+	c, err := rpc.DialContext(ctx, rawUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +52,7 @@ func (orc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*
 		blockStatuses    []*vanTypes.ConfirmationResData
 	)
 
+	// It's for now until we unify orc-van communication flow
 	for _, blockHash := range blockHashes {
 		orcBlockHash := &BlockHash{
 			Slot: uint64(blockHash.Slot),
@@ -67,6 +68,7 @@ func (orc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*
 		return nil, fmt.Errorf("rpcClient call context error, error is: %s", err.Error())
 	}
 
+	// It's for now until we unify orc-van communication flow
 	for _, orcBlockStatus := range orcBlockStatuses {
 		blockStatus := &vanTypes.ConfirmationResData{
 			Slot:   types.Slot(orcBlockStatus.Slot),

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -1,13 +1,31 @@
 package orchestrator_test
 
 import (
+	"bytes"
 	"context"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/prysm/beacon-chain/orchestrator"
+	vanTypes "github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"net"
 	"testing"
+	"time"
 )
+
+type orchestratorTestService struct {
+	unsubscribed            chan string
+	gotHangSubscriptionReq  chan struct{}
+	unblockHangSubscription chan struct{}
+}
+
+func newTestServer() *rpc.Server {
+	server := rpc.NewServer()
+	if err := server.RegisterName("orc", new(orchestratorTestService)); err != nil {
+		panic(err)
+	}
+	return server
+}
 
 func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 	ctx := context.Background()
@@ -17,11 +35,10 @@ func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 
 	orcRpcClient := orchestrator.NewClient(rpcClient)
 	assert.NotNil(t, orcRpcClient)
-
 	defer orcRpcClient.Close()
 
-	var blockHashes []*orchestrator.BlockHash
-	blockHash := &orchestrator.BlockHash{
+	var blockHashes []*vanTypes.ConfirmationReqData
+	blockHash := &vanTypes.ConfirmationReqData{
 		Slot: 0,
 		Hash: common.Hash{},
 	}
@@ -32,4 +49,74 @@ func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 		assert.ErrorContains(t, "dial tcp 127.0.0.1:8545: connect: connection refused", err)
 		assert.Equal(t, 0, len(blockStatuses))
 	})
+
+	t.Run("", func(t *testing.T) {
+		// TODO: mock comes here
+		// - add blocks to mocked server
+		// - retrieve confirmations and compare with expected ones
+	})
+}
+
+func TestName(t *testing.T) {
+	server := newTestServer()
+	defer server.Stop()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:8545")
+	if err != nil {
+		t.Fatal("can't listen:", err)
+	}
+	defer func(listener net.Listener) {
+		err := listener.Close()
+		if err != nil {
+
+		}
+	}(listener)
+
+	go func() {
+		err := server.ServeListener(listener)
+		if err != nil {
+			t.Error("listener error:", err)
+			return
+		}
+	}()
+
+	var (
+		request  = `{"jsonrpc":"1.0","id":1,"method":"orc_confirmVanBlockHashes"}` + "\n"
+		wantResp = `{"jsonrpc":"1.0","id":1,"result":{"nftest":"1.0","rpc":"1.0","test":"1.0"}}` + "\n"
+		deadline = time.Now().Add(10 * time.Second)
+	)
+	for i := 0; i < 20; i++ {
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			t.Fatal("can't dial:", err)
+		}
+		defer func(conn net.Conn) {
+			err := conn.Close()
+			if err != nil {
+				t.Error(err)
+			}
+		}(conn)
+		err = conn.SetDeadline(deadline)
+		if err != nil {
+			t.Error(err)
+		}
+		// Write the request, then half-close the connection so the server stops reading.
+		_, err = conn.Write([]byte(request))
+		if err != nil {
+			t.Error(err)
+		}
+		err = conn.(*net.TCPConn).CloseWrite()
+		if err != nil {
+			t.Error(err)
+		}
+		// Now try to get the response.
+		buf := make([]byte, 2000)
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatal("read error:", err)
+		}
+		if !bytes.Equal(buf[:n], []byte(wantResp)) {
+			t.Fatalf("wrong response: %s", buf[:n])
+		}
+	}
 }

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -1,0 +1,7 @@
+package orchestrator
+
+import "testing"
+
+func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
+
+}

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -1,8 +1,8 @@
 package orchestrator_test
 
 import (
-	"bytes"
 	"context"
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prysmaticlabs/prysm/beacon-chain/orchestrator"
@@ -10,8 +10,19 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"net"
 	"testing"
-	"time"
 )
+
+func listenTCP() (net.Listener, string) {
+	l, e := net.Listen("tcp", "127.0.0.1:8545") // any available address
+	if e != nil {
+		print(e.Error())
+	}
+	if l == nil {
+		panic("error: Listener is nil!")
+	}
+
+	return l, l.Addr().String()
+}
 
 type orchestratorTestService struct {
 	unsubscribed            chan string
@@ -19,104 +30,145 @@ type orchestratorTestService struct {
 	unblockHangSubscription chan struct{}
 }
 
+func (apiMock *orchestratorTestService) ConfirmVanBlockHashes(args []*vanTypes.ConfirmationReqData, reply []*vanTypes.ConfirmationResData) error {
+	for _, confirmationReq := range args {
+		exampleResp := &vanTypes.ConfirmationResData{
+			Slot:   confirmationReq.Slot,
+			// only for test purpose, for now
+			Hash:   confirmationReq.Hash,
+			Status: "Verified",
+		}
+		reply = append(reply, exampleResp)
+	}
+
+	return nil
+}
+
 func newTestServer() *rpc.Server {
-	server := rpc.NewServer()
-	if err := server.RegisterName("orc", new(orchestratorTestService)); err != nil {
+	newServer := rpc.NewServer()
+	if err := newServer.RegisterName("orc", new(orchestratorTestService)); err != nil {
 		panic(err)
 	}
-	return server
+
+	return newServer
 }
 
 func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 	ctx := context.Background()
-	httpPath := "http://127.0.0.1:8545"
-	rpcClient, err := rpc.Dial(httpPath)
-	assert.NoError(t, err)
+	rpcServer := newTestServer()
 
-	orcRpcClient := orchestrator.NewClient(rpcClient)
-	assert.NotNil(t, orcRpcClient)
-	defer orcRpcClient.Close()
+	defer rpcServer.Stop()
 
-	var blockHashes []*vanTypes.ConfirmationReqData
-	blockHash := &vanTypes.ConfirmationReqData{
-		Slot: 0,
-		Hash: common.Hash{},
-	}
-	blockHashes = append(blockHashes, blockHash)
-
-	t.Run("connection refused", func(t *testing.T) {
-		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, blockHashes)
-		assert.ErrorContains(t, "dial tcp 127.0.0.1:8545: connect: connection refused", err)
-		assert.Equal(t, 0, len(blockStatuses))
-	})
-
-	t.Run("", func(t *testing.T) {
-		// TODO: mock comes here
-		// - add blocks to mocked server
-		// - retrieve confirmations and compare with expected ones
-	})
-}
-
-func TestName(t *testing.T) {
-	server := newTestServer()
-	defer server.Stop()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:8545")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatal("can't listen:", err)
+		t.Fatalf("can't listen: %s", err.Error())
 	}
+
 	defer func(listener net.Listener) {
 		err := listener.Close()
 		if err != nil {
-
+			fmt.Println(err.Error())
 		}
 	}(listener)
 
 	go func() {
-		err := server.ServeListener(listener)
+		err := rpcServer.ServeListener(listener)
 		if err != nil {
-			t.Error("listener error:", err)
-			return
+			fmt.Println(err.Error())
 		}
 	}()
 
-	var (
-		request  = `{"jsonrpc":"1.0","id":1,"method":"orc_confirmVanBlockHashes"}` + "\n"
-		wantResp = `{"jsonrpc":"1.0","id":1,"result":{"nftest":"1.0","rpc":"1.0","test":"1.0"}}` + "\n"
-		deadline = time.Now().Add(10 * time.Second)
-	)
-	for i := 0; i < 20; i++ {
-		conn, err := net.Dial("tcp", listener.Addr().String())
-		if err != nil {
-			t.Fatal("can't dial:", err)
-		}
-		defer func(conn net.Conn) {
-			err := conn.Close()
-			if err != nil {
-				t.Error(err)
-			}
-		}(conn)
-		err = conn.SetDeadline(deadline)
-		if err != nil {
-			t.Error(err)
-		}
-		// Write the request, then half-close the connection so the server stops reading.
-		_, err = conn.Write([]byte(request))
-		if err != nil {
-			t.Error(err)
-		}
-		err = conn.(*net.TCPConn).CloseWrite()
-		if err != nil {
-			t.Error(err)
-		}
-		// Now try to get the response.
-		buf := make([]byte, 2000)
-		n, err := conn.Read(buf)
-		if err != nil {
-			t.Fatal("read error:", err)
-		}
-		if !bytes.Equal(buf[:n], []byte(wantResp)) {
-			t.Fatalf("wrong response: %s", buf[:n])
-		}
+	listenerAddr := "http://" + listener.Addr().String()
+
+	orcRpcClient, err := orchestrator.Dial(ctx, listenerAddr)
+	assert.NoError(t, err)
+
+	defer orcRpcClient.Close()
+
+	blockHashes := make([]*vanTypes.ConfirmationReqData, 1)
+	blockHash := &vanTypes.ConfirmationReqData{
+		Slot: 0,
+		Hash: common.Hash{},
 	}
+	blockHashes[0] = blockHash
+
+	t.Run("connection success", func(t *testing.T) {
+		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, blockHashes)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(blockStatuses))
+	})
+
+	//t.Run("test another rpc client flow", func(t *testing.T) {
+	//	client, err := orchestrator.Dial(ctx, listenerAddr)
+	//	if err != nil {
+	//		t.Fatalf("dialing error: %s", err.Error())
+	//	}
+	//
+	//	defer client.Close()
+	//
+	//	// Synchronous calls
+	//	args := &vanTypes.ConfirmationReqData{
+	//		Slot: 0,
+	//		Hash: [32]byte{},
+	//	}
+	//	var argsSlice []*vanTypes.ConfirmationReqData
+	//	argsSlice = append(argsSlice, args)
+	//
+	//	hashes, err := client.ConfirmVanBlockHashes(ctx, argsSlice)
+	//	if err != nil {
+	//		t.Fatalf("ConfirmVanBlockHashes error: %s", err.Error())
+	//	}
+	//
+	//	wantedResp := &vanTypes.ConfirmationResData{
+	//		Slot:   0,
+	//		Hash:   [32]byte{},
+	//		Status: "",
+	//	}
+	//
+	//	assert.DeepEqual(t, wantedResp, hashes)
+	//})
+
+	//t.Run("test request and response flow", func(t *testing.T) {
+	//	var (
+	//		request  = `{"jsonrpc":"1.0","id":1,"method":"orc_confirmVanBlockHashes","params":{"subtrahend": 23, "minuend": 42}}` + "\n"
+	//		wantResp = `{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"non-array args"}}` + "\n"
+	//		deadline = time.Now().Add(10 * time.Second)
+	//	)
+	//
+	//	conn, err := net.Dial("tcp", listener.Addr().String())
+	//	if err != nil {
+	//		t.Fatal("can't dial:", err)
+	//	}
+	//
+	//	defer func(conn net.Conn) {
+	//		err := conn.Close()
+	//		if err != nil {
+	//			t.Error(err)
+	//		}
+	//	}(conn)
+	//
+	//	err = conn.SetDeadline(deadline)
+	//	if err != nil {
+	//		t.Error(err)
+	//	}
+	//	// Write the request, then half-close the connection so the server stops reading.
+	//	_, err = conn.Write([]byte(request))
+	//	if err != nil {
+	//		t.Error(err)
+	//	}
+	//	err = conn.(*net.TCPConn).CloseWrite()
+	//	if err != nil {
+	//		t.Error(err)
+	//	}
+	//	// Now try to get the response.
+	//	buf := make([]byte, 2000)
+	//	n, err := conn.Read(buf)
+	//	if err != nil {
+	//		t.Fatal("read error:", err)
+	//	}
+	//	assert.DeepEqual(t, buf[:n], []byte(wantResp))
+	//	//if !bytes.Equal(buf[:n], []byte(wantResp)) {
+	//	//	t.Fatalf("wrong response: %s", buf[:n])
+	//	//}
+	//})
 }

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -1,7 +1,35 @@
-package orchestrator
+package orchestrator_test
 
-import "testing"
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/prysmaticlabs/prysm/beacon-chain/orchestrator"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"testing"
+)
 
 func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
+	ctx := context.Background()
+	httpPath := "http://127.0.0.1:8545"
+	rpcClient, err := rpc.Dial(httpPath)
+	assert.NoError(t, err)
 
+	orcRpcClient := orchestrator.NewClient(rpcClient)
+	assert.NotNil(t, orcRpcClient)
+
+	defer orcRpcClient.Close()
+
+	var blockHashes []*orchestrator.BlockHash
+	blockHash := &orchestrator.BlockHash{
+		Slot: 0,
+		Hash: common.Hash{},
+	}
+	blockHashes = append(blockHashes, blockHash)
+
+	t.Run("connection refused", func(t *testing.T) {
+		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, blockHashes)
+		assert.ErrorContains(t, "dial tcp 127.0.0.1:8545: connect: connection refused", err)
+		assert.Equal(t, 0, len(blockStatuses))
+	})
 }

--- a/beacon-chain/orchestrator/log.go
+++ b/beacon-chain/orchestrator/log.go
@@ -1,0 +1,5 @@
+package orchestrator
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("prefix", "orchestrator_rpc_client")

--- a/beacon-chain/orchestrator/types.go
+++ b/beacon-chain/orchestrator/types.go
@@ -1,0 +1,24 @@
+package orchestrator
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	Pending  Status = "Pending"
+	Verified Status = "Verified"
+	Invalid  Status = "Invalid"
+	Skipped  Status = "Skipped"
+)
+
+type Status string
+
+type BlockHash struct {
+	Slot uint64
+	Hash common.Hash
+}
+
+type BlockStatus struct {
+	BlockHash
+	Status Status
+}

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "testnet_toledo_config.go",
         "testutils.go",
         "values.go",
+        "van_types.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/shared/params",
     visibility = ["//visibility:public"],

--- a/shared/params/van_types.go
+++ b/shared/params/van_types.go
@@ -1,0 +1,27 @@
+package params
+
+import (
+	types "github.com/prysmaticlabs/eth2-types"
+)
+
+type Status string
+
+const (
+	Pending  Status = "Pending"
+	Verified Status = "Verified"
+	Invalid  Status = "Invalid"
+	Skipped  Status = "Skipped"
+)
+
+// ConfirmationReqData is used as a request param for getting confirmation from orchestrator
+type ConfirmationReqData struct {
+	Slot types.Slot
+	Hash [32]byte
+}
+
+// ConfirmationResData is used as a response param for getting confirmation from orchestrator
+type ConfirmationResData struct {
+	Slot types.Slot
+	Hash [32]byte
+	Status Status
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This feature provides `orchestrator` RPC client in `vanguard` beacon-chain client. It's required to achieve `orc_confirmVanBlockHashes` from https://gist.github.com/frozeman/d52090f3b8c4b654cacc279d894df31c document.

**Which issues(s) does this PR fix?**

Fixes https://github.com/lukso-network/vanguard-consensus-engine/issues/21

**Other notes for review**
