### PR TITLE
Feature/21/orc rpc client confirm blocks

### DIFF
--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -60,11 +60,13 @@ func (orc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*
 
 	// It's for now until we unify orc-van communication flow
 	for _, blockHash := range blockHashes {
-		orcBlockHash := &BlockHash{
-			Slot: uint64(blockHash.Slot),
-			Hash: common.BytesToHash(blockHash.Hash[:]),
+		if blockHash != nil {
+			orcBlockHash := &BlockHash{
+				Slot: uint64(blockHash.Slot),
+				Hash: common.BytesToHash(blockHash.Hash[:]),
+			}
+			orcBlockHashes = append(orcBlockHashes, orcBlockHash)
 		}
-		orcBlockHashes = append(orcBlockHashes, orcBlockHash)
 	}
 
 	err := orc.client.CallContext(ctx, &orcBlockStatuses, confirmVanBlockHashesMethod, orcBlockHashes)

--- a/beacon-chain/orchestrator/client.go
+++ b/beacon-chain/orchestrator/client.go
@@ -78,12 +78,14 @@ func (orc *RPCClient) ConfirmVanBlockHashes(ctx context.Context, blockHashes []*
 
 	// It's for now until we unify orc-van communication flow
 	for _, orcBlockStatus := range orcBlockStatuses {
-		blockStatus := &vanTypes.ConfirmationResData{
-			Slot:   types.Slot(orcBlockStatus.Slot),
-			Hash:   orcBlockStatus.Hash,
-			Status: vanTypes.Status(orcBlockStatus.Status),
+		if orcBlockStatus != nil {
+			blockStatus := &vanTypes.ConfirmationResData{
+				Slot:   types.Slot(orcBlockStatus.Slot),
+				Hash:   orcBlockStatus.Hash,
+				Status: vanTypes.Status(orcBlockStatus.Status),
+			}
+			blockStatuses = append(blockStatuses, blockStatus)
 		}
-		blockStatuses = append(blockStatuses, blockStatus)
 	}
 
 	return blockStatuses, nil

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -90,10 +90,19 @@ func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 	}
 	expectedBlockStatuses[0] = expectedBlockStatus
 
+	// Test cases
 	t.Run("connection success and returned with 1 verified block", func(t *testing.T) {
 		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, blockHashes)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blockStatuses))
 		assert.DeepEqual(t, expectedBlockStatuses, blockStatuses)
+	})
+
+	t.Run("connection success and empty request", func(t *testing.T) {
+		emptyBlockHashes := make([]*vanTypes.ConfirmationReqData, 1)
+		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, emptyBlockHashes)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(blockStatuses))
+		assert.DeepEqual(t, []*vanTypes.ConfirmationResData(nil), blockStatuses)
 	})
 }

--- a/beacon-chain/orchestrator/client_test.go
+++ b/beacon-chain/orchestrator/client_test.go
@@ -71,16 +71,29 @@ func TestRPCClient_ConfirmVanBlockHashes(t *testing.T) {
 	defer orcRpcClient.Close()
 
 	// Perform tests
+	exampleHash := common.HexToHash("0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553")
+
+	// Request
 	blockHashes := make([]*vanTypes.ConfirmationReqData, 1)
 	blockHash := &vanTypes.ConfirmationReqData{
 		Slot: 0,
-		Hash: common.HexToHash("0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553"),
+		Hash: exampleHash,
 	}
 	blockHashes[0] = blockHash
+
+	// Response
+	expectedBlockStatuses := make([]*vanTypes.ConfirmationResData, 1)
+	expectedBlockStatus := &vanTypes.ConfirmationResData{
+		Slot:   0,
+		Hash:   exampleHash,
+		Status: "Verified",
+	}
+	expectedBlockStatuses[0] = expectedBlockStatus
 
 	t.Run("connection success and returned with 1 verified block", func(t *testing.T) {
 		blockStatuses, err := orcRpcClient.ConfirmVanBlockHashes(ctx, blockHashes)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(blockStatuses))
+		assert.DeepEqual(t, expectedBlockStatuses, blockStatuses)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This feature provides `orchestrator` RPC client in `vanguard` beacon-chain client. It's required to achieve `orc_confirmVanBlockHashes` from https://gist.github.com/frozeman/d52090f3b8c4b654cacc279d894df31c document.

**Which issues(s) does this PR fix?**

Fixes https://github.com/lukso-network/vanguard-consensus-engine/issues/21

**Other notes for review**
