### PR TITLE
Feature: 21 orchestrator rpc client for blocks confirmation flow

### DIFF
--- a/shared/params/van_types.go
+++ b/shared/params/van_types.go
@@ -21,7 +21,7 @@ type ConfirmationReqData struct {
 
 // ConfirmationResData is used as a response param for getting confirmation from orchestrator
 type ConfirmationResData struct {
-	Slot types.Slot
-	Hash [32]byte
+	Slot   types.Slot
+	Hash   [32]byte
 	Status Status
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This feature provides `orchestrator` RPC client in `vanguard` beacon-chain client. It's required to achieve `orc_confirmVanBlockHashes` from https://gist.github.com/frozeman/d52090f3b8c4b654cacc279d894df31c document.

**Which issues(s) does this PR fix?**

Fixes https://github.com/lukso-network/vanguard-consensus-engine/issues/21

**Other notes for review**
