### PR TITLE
Feature: l15 config provided via flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -37,6 +37,7 @@ type Flags struct {
 	// Testnet Flags.
 	ToledoTestnet  bool // ToledoTestnet defines the flag through which we can enable the node to run on the Toledo testnet.
 	PyrmontTestnet bool // PyrmontTestnet defines the flag through which we can enable the node to run on the Pyrmont testnet.
+	L15TestNet     bool // L15Testnet defines the flag for LUKSO L15 test net
 
 	// Feature related flags.
 	WriteSSZStateTransitions           bool // WriteSSZStateTransitions to tmp directory.
@@ -124,6 +125,10 @@ func configureTestnet(ctx *cli.Context, cfg *Flags) {
 		params.UsePyrmontConfig()
 		params.UsePyrmontNetworkConfig()
 		cfg.PyrmontTestnet = true
+	} else if ctx.Bool(L15TestNet.Name) {
+		log.Warn("Running on the L15 LUKSO Testnet")
+		params.UseL15Config()
+		params.UseL15NetworkConfig()
 	} else if ctx.Bool(PraterTestnet.Name) {
 		log.Warn("Running on the Prater Testnet")
 		params.UsePraterConfig()

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -21,6 +21,10 @@ var (
 	PraterTestnet = &cli.BoolFlag{
 		Name:  "prater",
 		Usage: "Run Prysm configured for the Prater test network",
+	} // PraterTestnet flag for the multiclient eth2 testnet.
+	L15TestNet = &cli.BoolFlag{
+		Name:  "l15",
+		Usage: "Run Vanguard configured for the L15 LUKSO test network",
 	}
 	// Mainnet flag for easier tooling, no-op
 	Mainnet = &cli.BoolFlag{
@@ -141,6 +145,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	ToledoTestnet,
 	PyrmontTestnet,
 	PraterTestnet,
+	L15TestNet,
 	Mainnet,
 	disableAccountsV2,
 	disableBlst,
@@ -155,6 +160,7 @@ var SlasherFlags = append(deprecatedFlags, []cli.Flag{
 	ToledoTestnet,
 	PyrmontTestnet,
 	PraterTestnet,
+	L15TestNet,
 	Mainnet,
 }...)
 
@@ -171,6 +177,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	ToledoTestnet,
 	PyrmontTestnet,
 	PraterTestnet,
+	L15TestNet,
 	Mainnet,
 	disableBlst,
 	enablePeerScorer,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -21,7 +21,7 @@ var (
 	PraterTestnet = &cli.BoolFlag{
 		Name:  "prater",
 		Usage: "Run Prysm configured for the Prater test network",
-	} // PraterTestnet flag for the multiclient eth2 testnet.
+	}
 	L15TestNet = &cli.BoolFlag{
 		Name:  "l15",
 		Usage: "Run Vanguard configured for the L15 LUKSO test network",

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "testnet_prater_config.go",
         "testnet_pyrmont_config.go",
         "testnet_toledo_config.go",
+        "testnet_l15_config.go",
         "testutils.go",
         "values.go",
         "van_types.go",

--- a/shared/params/testnet_l15_config.go
+++ b/shared/params/testnet_l15_config.go
@@ -1,0 +1,38 @@
+package params
+
+// UseL15NetworkConfig uses the Lukso specific
+// network config.
+func UseL15NetworkConfig() {
+	cfg := BeaconNetworkConfig().Copy()
+	cfg.ContractDeploymentBlock = 0
+	cfg.BootstrapNodes = []string{
+		"enr:-Ku4QEL0I7H3EawRwc2ZUevmj-_T0R6JZGMhfp_2KHBlwAt5bwA19c8LSYZzy63EvpsYbifKye6qnE-_vsNimWOz8scBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCvIkw2g6VTF___________gmlkgnY0gmlwhCPqeliJc2VjcDI1NmsxoQLt36VpP56n0SlTYWcSBwL7aGK_AFwNLGxOGQt91nchMYN1ZHCCEuk",
+		"enr:-Ku4QAmYtwrQBZ-WJwTPL4xMpTO6BlZcU6IuXljtd_SgC51nGRs98WvxCX0-ZJBs0G9m9tcFPsktbdSr7EliMhrZnfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCvIkw2g6VTF___________gmlkgnY0gmlwhCKNcPOJc2VjcDI1NmsxoQLt36VpP56n0SlTYWcSBwL7aGK_AFwNLGxOGQt91nchMYN1ZHCCEuk",
+		"enr:-Ku4QEXRrSXB7od-xNeoLuq6GicTHpuuCNRPPR9tM48Iai0-FoHL4JsntmpnwUrC-di-lT6gkbxV7Jikg9s6ImsAT1oBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCvIkw2g6VTF___________gmlkgnY0gmlwhCPGqi6Jc2VjcDI1NmsxoQLt36VpP56n0SlTYWcSBwL7aGK_AFwNLGxOGQt91nchMYN1ZHCCEuk",
+		"enr:-Ku4QBuS5wqvF6SHaPpuu4r4ZlRRVC1Ojp1zDOAVC1X0PB3gRujAhWZdk2m0kn3FwoPuHft_Sku0tWHSfBVlHoER160Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCvIkw2g6VTF___________gmlkgnY0gmlwhCKNLsqJc2VjcDI1NmsxoQLt36VpP56n0SlTYWcSBwL7aGK_AFwNLGxOGQt91nchMYN1ZHCCEuk",
+	}
+	OverrideBeaconNetworkConfig(cfg)
+}
+
+// UseL15Config sets the main beacon chain
+// config for Lukso.
+func UseL15Config() {
+	beaconConfig = L15Config()
+}
+
+// L15Config defines the config for the
+// Lukso testnet.
+func L15Config() *BeaconChainConfig {
+	cfg := MainnetConfig().Copy()
+	cfg.MinGenesisTime = 1627579138
+	cfg.GenesisDelay = 0
+	cfg.ConfigName = ConfigNames[L15]
+	cfg.GenesisForkVersion = []byte{0x83, 0xa5, 0x53, 0x17}
+	cfg.SecondsPerETH1Block = 6
+	cfg.SlotsPerEpoch = 32
+	cfg.SecondsPerSlot = 6
+	cfg.DepositChainID = 808081
+	cfg.DepositNetworkID = 808081
+	cfg.DepositContractAddress = "0x000000000000000000000000000000000000cafe"
+	return cfg
+}

--- a/shared/params/values.go
+++ b/shared/params/values.go
@@ -6,6 +6,7 @@ const (
 	Pyrmont
 	Toledo
 	Prater
+	L15
 )
 
 // ConfigNames provides network configuration names.
@@ -15,6 +16,7 @@ var ConfigNames = map[ConfigName]string{
 	Pyrmont:  "pyrmont",
 	Toledo:   "toledo",
 	Prater:   "prater",
+	L15:      "l15",
 }
 
 // ConfigName enum describes the type of known network in use.


### PR DESCRIPTION
This PR allows to provide flag for config `-l15` to reduce the complexity behind config propagation