### PR TITLE
Fix header decoding issue after integrating london hard fork

### DIFF
--- a/shared/mock/beacon_service_mock.go
+++ b/shared/mock/beacon_service_mock.go
@@ -479,7 +479,7 @@ func (mr *MockBeaconChainClientMockRecorder) StreamMinimalConsensusInfo(arg0, ar
 }
 
 // StreamNewPendingBlocks mocks base method
-func (m *MockBeaconChainClient) StreamNewPendingBlocks(arg0 context.Context, arg1 *emptypb.Empty, arg2 ...grpc.CallOption) (eth.BeaconChain_StreamNewPendingBlocksClient, error) {
+func (m *MockBeaconChainClient) StreamNewPendingBlocks(arg0 context.Context, arg1 *eth.StreamPendingBlocksRequest, arg2 ...grpc.CallOption) (eth.BeaconChain_StreamNewPendingBlocksClient, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {

--- a/validator/client/pan_propose.go
+++ b/validator/client/pan_propose.go
@@ -286,7 +286,7 @@ func (v *validator) preparePandoraShardingInfo(
 func sealHash(header *eth1Types.Header) (hash common.Hash) {
 	hasher := sha3.NewLegacyKeccak256()
 
-	if err := rlp.Encode(hasher, []interface{}{
+	enc := []interface{}{
 		header.ParentHash,
 		header.UncleHash,
 		header.Coinbase,
@@ -300,7 +300,11 @@ func sealHash(header *eth1Types.Header) (hash common.Hash) {
 		header.GasUsed,
 		header.Time,
 		header.Extra,
-	}); err != nil {
+	}
+	if header.BaseFee != nil {
+		enc = append(enc, header.BaseFee)
+	}
+	if err := rlp.Encode(hasher, enc); err != nil {
 		return eth1Types.EmptyRootHash
 	}
 	hasher.Sum(hash[:0])


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix

**What does this PR do? Why is it needed?**

It fixes header decoding issue after integrating london hard fork. In EIP-1559, geth implements a new field in header which is called `BaseFee`. In our pandora consensus implementation, we haven't add this field when we called `SealHash` method. That's why when validator tried to decode the header, it was failed.
