### PR TITLE
Fix verifyPandoraShardInfo panics

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -1150,9 +1150,11 @@ func TestVerifyPandoraShardInfo(t *testing.T) {
 			if tt.wantErr {
 				assert.NotNil(t, err)
 				assert.DeepEqual(t, tt.wantErrString, err.Error())
-			} else {
-				assert.NoError(t, err)
+
+				return
 			}
+
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -1048,3 +1048,92 @@ func TestRemoveBlockAttestationsInPool_NonCanonical(t *testing.T) {
 	require.NoError(t, service.pruneCanonicalAttsFromPool(ctx, r, wrapper.WrappedPhase0SignedBeaconBlock(b)))
 	require.Equal(t, 1, service.cfg.AttPool.AggregatedAttestationCount())
 }
+
+func TestVerifyPandoraShardInfo(t *testing.T) {
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+
+	cfg := &Config{
+		BeaconDB: beaconDB,
+		StateGen: stategen.New(beaconDB),
+	}
+	service, err := NewService(ctx, cfg)
+	require.NoError(t, err)
+
+	s, err := v1.InitializeFromProto(&pb.BeaconState{Slot: 1, GenesisValidatorsRoot: params.BeaconConfig().ZeroHash[:]})
+	require.NoError(t, err)
+
+	genesisStateRoot := [32]byte{}
+	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
+	assert.NoError(t, beaconDB.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(genesis)))
+	gRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	service.finalizedCheckpt = &ethpb.Checkpoint{
+		Root: gRoot[:],
+	}
+	service.cfg.ForkChoiceStore = protoarray.New(0, 0, [32]byte{})
+	service.saveInitSyncBlock(gRoot, wrapper.WrappedPhase0SignedBeaconBlock(genesis))
+
+	tests := []struct {
+		name          string
+		blk           *ethpb.SignedBeaconBlock
+		time          uint64
+		wantErr       bool
+		wantErrString string
+	}{
+		{
+			name: "Test with proper parent block and slot = 1",
+			blk: func() *ethpb.SignedBeaconBlock {
+				b := testutil.NewBeaconBlock()
+				b.Block.ParentRoot = gRoot[:]
+				b.Block.Slot = 1
+				return b
+			}(),
+		},
+		{
+			name: "Test with proper parent block and slot != 1",
+			blk: func() *ethpb.SignedBeaconBlock {
+				b := testutil.NewBeaconBlock()
+				b.Block.ParentRoot = gRoot[:]
+				b.Block.Slot = 2
+				return b
+			}(),
+		},
+		{
+			name: "Test with invalid parent block and slot != 1",
+			blk: func() *ethpb.SignedBeaconBlock {
+				b := testutil.NewBeaconBlock()
+				b.Block.ParentRoot = nil
+				b.Block.Slot = 2
+				return b
+			}(),
+			wantErr:       true,
+			wantErrString: "unknown parent beacon block",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, service.cfg.BeaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: gRoot[:]}))
+			require.NoError(t, service.cfg.StateGen.SaveState(ctx, gRoot, s))
+			if !tt.wantErr {
+				require.NoError(t, service.verifyBlkPreState(ctx, wrapper.WrappedPhase0BeaconBlock(tt.blk.Block)))
+			}
+
+			b := wrapper.WrappedPhase0SignedBeaconBlock(tt.blk).Copy()
+			blk := b.Block()
+
+			parentRoot := bytesutil.ToBytes32(blk.ParentRoot())
+			parentBlk, err := service.cfg.BeaconDB.Block(service.ctx, parentRoot)
+			assert.NoError(t, err)
+
+			err = service.verifyPandoraShardInfo(parentBlk, b)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				assert.DeepEqual(t, tt.wantErrString, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/beacon-chain/blockchain/van_process_pending_blocks.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	blockfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/block"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/interfaces"
 	vanTypes "github.com/prysmaticlabs/prysm/shared/params"
 	"time"
@@ -222,13 +223,20 @@ func (s *Service) waitForConfirmation(b interfaces.SignedBeaconBlock) error {
 
 // verifyPandoraShardInfo
 func (s *Service) verifyPandoraShardInfo(parentBlk, curBlk interfaces.SignedBeaconBlock) error {
+	var parentPanShards []*ethpb.PandoraShard
+
 	// For slot #1, we don't have shard info for previous block so short circuit here
 	if curBlk.Block().Slot() == 1 {
 		return nil
 	}
 	// Checking length of current block's pandora shard info
 	curPanShards := curBlk.Block().Body().PandoraShards()
-	parentPanShards := parentBlk.Block().Body().PandoraShards()
+
+	if parentBlk == nil || len(parentBlk.Block().Body().PandoraShards()) == 0 {
+		return nil
+	}
+
+	parentPanShards = parentBlk.Block().Body().PandoraShards()
 
 	if len(curPanShards) > 0 && len(parentPanShards) > 0 {
 		// Checking current block pandora shard's parent with canonical head's pandora shard's header hash

--- a/beacon-chain/blockchain/van_process_pending_blocks.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks.go
@@ -32,9 +32,7 @@ var (
 	errInvalidConfirmationData    = errors.New("invalid orchestrator confirmation")
 	errParentDoesNotExist         = errors.New("beacon node doesn't have a parent in db with root")
 	errUnknownParent              = errors.New("unknown parent beacon block")
-	errUnknownParentBody          = errors.New("unknown parent beacon block body")
 	errUnknownCurrent             = errors.New("unknown current beacon block")
-	errUnknownCurrentBody         = errors.New("unknown current beacon block body")
 )
 
 // orcConfirmationData is the data which is sent after getting confirmation from orchestrator
@@ -52,56 +50,48 @@ type PendingQueueFetcher interface {
 	OrcVerification() bool
 }
 
-// CanPropose
 func (s *Service) CanPropose() bool {
 	s.canProposeLock.RLock()
 	defer s.canProposeLock.RUnlock()
 	return s.canPropose
 }
 
-// ActivateOrcVerification
 func (s *Service) ActivateOrcVerification() {
 	s.orcVerificationLock.Lock()
 	defer s.orcVerificationLock.Unlock()
 	s.orcVerification = true
 }
 
-// DeactivateOrcVerification
 func (s *Service) DeactivateOrcVerification() {
 	s.orcVerificationLock.Lock()
 	defer s.orcVerificationLock.Unlock()
 	s.orcVerification = false
 }
 
-// OrcVerification
 func (s *Service) OrcVerification() bool {
 	s.orcVerificationLock.RLock()
 	defer s.orcVerificationLock.RUnlock()
 	return s.orcVerification
 }
 
-// setLatestSentEpoch
 func (s *Service) setLatestSentEpoch(epoch types.Epoch) {
 	s.latestSentEpochLock.Lock()
 	defer s.latestSentEpochLock.Unlock()
 	s.latestSentEpoch = epoch
 }
 
-// getLatestSentEpoch
 func (s *Service) getLatestSentEpoch() types.Epoch {
 	s.latestSentEpochLock.RLock()
 	defer s.latestSentEpochLock.RUnlock()
 	return s.latestSentEpoch
 }
 
-// deactivateBlockProposal
 func (s *Service) deactivateBlockProposal() {
 	s.canProposeLock.Lock()
 	defer s.canProposeLock.Unlock()
 	s.canPropose = false
 }
 
-// activateBlockProposal
 func (s *Service) activateBlockProposal() {
 	s.canProposeLock.Lock()
 	defer s.canProposeLock.Unlock()

--- a/beacon-chain/blockchain/van_process_pending_blocks.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks.go
@@ -232,7 +232,7 @@ func (s *Service) verifyPandoraShardInfo(parentBlk, curBlk interfaces.SignedBeac
 	// Checking length of current block's pandora shard info
 	curPanShards := curBlk.Block().Body().PandoraShards()
 
-	if parentBlk == nil || len(parentBlk.Block().Body().PandoraShards()) == 0 {
+	if parentBlk.IsNil() || len(parentBlk.Block().Body().PandoraShards()) == 0 {
 		return nil
 	}
 

--- a/beacon-chain/blockchain/van_process_pending_blocks.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks.go
@@ -28,6 +28,7 @@ var (
 	errInvalidRpcClientResLen     = errors.New("invalid length of orchestrator confirmation response")
 	errInvalidConfirmationData    = errors.New("invalid orchestrator confirmation")
 	errParentDoesNotExist         = errors.New("beacon node doesn't have a parent in db with root")
+	errUnknownParent              = errors.New("unknown parent")
 )
 
 // ConfirmedData is the data which is sent after getting confirmation from orchestrator
@@ -232,8 +233,8 @@ func (s *Service) verifyPandoraShardInfo(parentBlk, curBlk interfaces.SignedBeac
 	// Checking length of current block's pandora shard info
 	curPanShards := curBlk.Block().Body().PandoraShards()
 
-	if parentBlk.IsNil() || len(parentBlk.Block().Body().PandoraShards()) == 0 {
-		return nil
+	if parentBlk == nil || parentBlk.IsNil() || parentBlk.Block().IsNil() {
+		return errUnknownParent
 	}
 
 	parentPanShards = parentBlk.Block().Body().PandoraShards()

--- a/beacon-chain/blockchain/van_process_pending_blocks_test.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks_test.go
@@ -39,7 +39,6 @@ func TestService_PublishBlock(t *testing.T) {
 	require.NoError(t, err)
 	b := testutil.NewBeaconBlock()
 	wrappedBlk := wrapper.WrappedPhase0SignedBeaconBlock(b)
-
 	s.publishBlock(wrappedBlk)
 	time.Sleep(3 * time.Second)
 	if recvd := len(s.blockNotifier.(*mock.MockBlockNotifier).ReceivedEvents()); recvd < 1 {

--- a/beacon-chain/blockchain/van_process_pending_blocks_test.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks_test.go
@@ -207,6 +207,7 @@ func TestService_PandoraShardInfo(t *testing.T) {
 	require.NoError(t, err)
 	err = s.verifyPandoraShardInfo(parentBlk, wrappedBlk)
 	require.NoError(t, err)
+	s.publishBlock(wrappedBlk)
 	time.Sleep(3 * time.Second)
 	if recvd := len(s.blockNotifier.(*mock.MockBlockNotifier).ReceivedEvents()); recvd < 1 {
 		t.Errorf("Received %d pending block notifications, expected at least 1", recvd)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

I've figured out when I was testing `l15-vm-5` that `verifyPandoraShardInfo` panics with `nil` block or body or `nil pointer` of `parentBlk` or `currBlk`.

**Which issues(s) does this PR fix?**

This PR changes should fix panic from `verifyPandoraShardInfo`. This implementation solves also some typos and Law of Demeter issues.

**Other notes for review**

None.