### PR TITLE
Fix parent not found issue

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -123,6 +123,17 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 				"%d and parentRoot: %#x", b.Slot(), b.ParentRoot())
 		}
 
+		// If the block does not exist in db, check again if block exists in initial sync block cache.
+		// This could happen as the node first syncs to head.
+		if (parentBlk == nil || parentBlk.IsNil()) && s.hasInitSyncBlock(parentRoot) {
+			parentBlk = s.getInitSyncBlock(parentRoot)
+		}
+
+		if parentBlk == nil {
+			return errors.Wrapf(errParentDoesNotExist, "could not verify pandora shard info "+
+				"onBlock with slot: %d and parentHash: %#x", b.Slot(), b.ParentRoot())
+		}
+
 		// verify pandora sharding info in live sync mode
 		if err := s.verifyPandoraShardInfo(parentBlk, signed); err != nil {
 			return errors.Wrap(err, "could not verify pandora shard info onBlock")
@@ -315,6 +326,17 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 		parentRoot := bytesutil.ToBytes32(blks[0].Block().ParentRoot())
 		parentBlk, err := s.cfg.BeaconDB.Block(s.ctx, parentRoot)
 		if err != nil {
+			return nil, nil, errors.Wrapf(errParentDoesNotExist, "could not verify pandora shard info "+
+				"onBlockBatch with slot: %d and parentHash: %#x", blks[0].Block().Slot(), blks[0].Block().ParentRoot())
+		}
+
+		// If the block does not exist in db, check again if block exists in initial sync block cache.
+		// This could happen as the node first syncs to head.
+		if (parentBlk == nil || parentBlk.IsNil()) && s.hasInitSyncBlock(parentRoot) {
+			parentBlk = s.getInitSyncBlock(parentRoot)
+		}
+
+		if parentBlk == nil {
 			return nil, nil, errors.Wrapf(errParentDoesNotExist, "could not verify pandora shard info "+
 				"onBlockBatch with slot: %d and parentHash: %#x", blks[0].Block().Slot(), blks[0].Block().ParentRoot())
 		}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -125,11 +125,11 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 
 		// If the block does not exist in db, check again if block exists in initial sync block cache.
 		// This could happen as the node first syncs to head.
-		if (parentBlk == nil || parentBlk.IsNil()) && s.hasInitSyncBlock(parentRoot) {
+		if parentBlk.IsNil() && s.hasInitSyncBlock(parentRoot) {
 			parentBlk = s.getInitSyncBlock(parentRoot)
 		}
 
-		if parentBlk == nil {
+		if parentBlk.IsNil() {
 			return errors.Wrapf(errParentDoesNotExist, "could not verify pandora shard info "+
 				"onBlock with slot: %d and parentHash: %#x", b.Slot(), b.ParentRoot())
 		}
@@ -332,11 +332,11 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 
 		// If the block does not exist in db, check again if block exists in initial sync block cache.
 		// This could happen as the node first syncs to head.
-		if (parentBlk == nil || parentBlk.IsNil()) && s.hasInitSyncBlock(parentRoot) {
+		if parentBlk.IsNil() && s.hasInitSyncBlock(parentRoot) {
 			parentBlk = s.getInitSyncBlock(parentRoot)
 		}
 
-		if parentBlk == nil {
+		if parentBlk.IsNil() {
 			return nil, nil, errors.Wrapf(errParentDoesNotExist, "could not verify pandora shard info "+
 				"onBlockBatch with slot: %d and parentHash: %#x", blks[0].Block().Slot(), blks[0].Block().ParentRoot())
 		}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

In `onBlockBatch` method, vanguard is now verifying pandora shard info so it needs to have parent block. Previously vanguard tried to find parent block only from DB but in batch verification, prysm stores block in cache first then stores blocks in DB. 

So finding from cache was missing previous implementation. 

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
