### PR TITLE
Orchestrator verification is always active

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -134,7 +134,7 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 				"onBlock with slot: %d and parentHash: %#x", b.Slot(), b.ParentRoot())
 		}
 
-		// verify pandora sharding info in live sync mode
+		// verify pandora sharding info in regular sync mode
 		if err := s.verifyPandoraShardInfo(parentBlk, signed); err != nil {
 			return errors.Wrap(err, "could not verify pandora shard info onBlock")
 		}
@@ -142,7 +142,7 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 		// publish block to orchestrator and rpc service for sending minimal consensus info
 		s.publishBlock(signed)
 
-		// waiting for orchestrator confirmation in live-sync mode
+		// waiting for orchestrator confirmation in regular sync mode
 		if err := s.waitForConfirmation(signed); err != nil {
 			return errors.Wrap(err, "could not publish and verified by orchestrator client onBlock")
 		}
@@ -343,7 +343,7 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 			if i > 0 {
 				parentBlk = blks[i-1]
 			}
-			// verify pandora sharding info in live sync mode
+			// verify pandora sharding info in regular sync mode
 			if err := s.verifyPandoraShardInfo(parentBlk, blks[i]); err != nil {
 				return nil, nil, errors.Wrap(err, "could not verify pandora shard info onBlockBatch")
 			}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -142,11 +142,9 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 		// publish block to orchestrator and rpc service for sending minimal consensus info
 		s.publishBlock(signed)
 
-		if s.OrcVerification() {
-			// waiting for orchestrator confirmation in live-sync mode
-			if err := s.waitForConfirmation(signed); err != nil {
-				return errors.Wrap(err, "could not publish and verified by orchestrator client onBlock")
-			}
+		// waiting for orchestrator confirmation in live-sync mode
+		if err := s.waitForConfirmation(signed); err != nil {
+			return errors.Wrap(err, "could not publish and verified by orchestrator client onBlock")
 		}
 	}
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -349,6 +349,11 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 			}
 			// publish block and trigger rpc service for sending minimal consensus info
 			s.publishBlock(blks[i])
+
+			// waiting for orchestrator confirmation in regular sync mode
+			if err := s.waitForConfirmation(blks[i]); err != nil {
+				return nil, nil, errors.Wrap(err, "could not publish and verified by orchestrator client onBlock")
+			}
 		}
 	}
 

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -72,9 +72,7 @@ type Service struct {
 
 	// Vanguard: unconfirmed blocks need to store in cache for waiting final confirmation from orchestrator
 	enableVanguardNode  bool
-	orcVerification     bool
 	canPropose          bool
-	orcVerificationLock sync.RWMutex
 	canProposeLock      sync.RWMutex
 	latestSentEpochLock sync.RWMutex
 	orcRPCClient        orchestrator.Client
@@ -121,7 +119,6 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 		// Vanguard consensus related fields initialization
 		orcRPCClient:       cfg.OrcRPCClient,
 		enableVanguardNode: cfg.EnableVanguardNode,
-		orcVerification:    true,
 		canPropose:         true,
 	}
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -428,18 +428,6 @@ func (s *ChainService) ChainHeads() ([][32]byte, []types.Slot) {
 		[]types.Slot{0, 1}
 }
 
-func (s *ChainService) ActivateOrcVerification() {
-	return
-}
-
 func (s *ChainService) CanPropose() bool {
-	return true
-}
-
-func (s *ChainService) DeactivateOrcVerification() {
-	return
-}
-
-func (s *ChainService) OrcVerification() bool {
 	return true
 }

--- a/beacon-chain/blockchain/van_process_pending_blocks.go
+++ b/beacon-chain/blockchain/van_process_pending_blocks.go
@@ -45,33 +45,12 @@ type orcConfirmationData struct {
 // PendingQueueFetcher interface use when validator calls GetBlock api for proposing new beancon block
 type PendingQueueFetcher interface {
 	CanPropose() bool
-	ActivateOrcVerification()
-	DeactivateOrcVerification()
-	OrcVerification() bool
 }
 
 func (s *Service) CanPropose() bool {
 	s.canProposeLock.RLock()
 	defer s.canProposeLock.RUnlock()
 	return s.canPropose
-}
-
-func (s *Service) ActivateOrcVerification() {
-	s.orcVerificationLock.Lock()
-	defer s.orcVerificationLock.Unlock()
-	s.orcVerification = true
-}
-
-func (s *Service) DeactivateOrcVerification() {
-	s.orcVerificationLock.Lock()
-	defer s.orcVerificationLock.Unlock()
-	s.orcVerification = false
-}
-
-func (s *Service) OrcVerification() bool {
-	s.orcVerificationLock.RLock()
-	defer s.orcVerificationLock.RUnlock()
-	return s.orcVerification
 }
 
 func (s *Service) setLatestSentEpoch(epoch types.Epoch) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -200,12 +200,6 @@ func (vs *Server) ProposeBlock(ctx context.Context, rBlk *ethpb.SignedBeaconBloc
 		"blockRoot": hex.EncodeToString(root[:]),
 	}).Debug("Broadcasting block")
 
-	//Vanguard: Activating orchestrator verification in live sync mode when pandora client will be also in live sync mode
-	if vs.EnableVanguardNode && !vs.PendingQueueFetcher.OrcVerification() {
-		log.WithField("slot", blk.Block().Slot()).Info("Activating orchestrator verification in live sync mode")
-		vs.PendingQueueFetcher.ActivateOrcVerification()
-	}
-
 	if err := vs.BlockReceiver.ReceiveBlock(ctx, blk, root); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process beacon block: %v", err)
 	}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -104,11 +104,6 @@ func (s *Service) Start() {
 		s.markSynced(genesis)
 		return
 	}
-	// Vanguard: Deactivating verification from orchestrator client
-	if s.cfg.EnableVanguardNode {
-		log.Info("Deactivating orchestrator verification in initial sync mode")
-		s.cfg.Chain.DeactivateOrcVerification()
-	}
 	s.waitForMinimumPeers()
 	if err := s.roundRobinSync(genesis); err != nil {
 		if errors.Is(s.ctx.Err(), context.Canceled) {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This change is required to achieve new `lukso-orchestrator` consensus service design, which requires `vanguard` to always wait for confirmation from `lukso-orchestrator`. In the `vanguard` implementation it's `waitForConfirmation`

**Which issues(s) does this PR fix?**

This issue solves https://app.clickup.com/t/1vc1xm9 TODOS called: `[VAN] Orchestrator verification will be activated at any time.`

**Other notes for review**

Internal docs for `Orchestrator` architecture: https://www.notion.so/lukso/Orchestrator-3707d9c1e0994e748da5ebfb124cf1de