### PR TITLE
Orchestrator verification disable in initial syncing process or re-sync mod

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -627,6 +627,7 @@ func (b *BeaconNode) registerRPCService() error {
 		// vanguard: EnableVanguardNode and UnconfirmedBlockFetcher is used for vanguard chain
 		EnableVanguardNode:  b.cliCtx.Bool(cmd.VanguardNetwork.Name),
 		PendingQueueFetcher: chainService,
+		SyncStatus:          syncService,
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/server.go
@@ -49,4 +49,5 @@ type Server struct {
 	SyncChecker                 sync.Checker
 	// Vanguard: pending blocks cache
 	PendingQueueFetcher blockchain.PendingQueueFetcher
+	SyncStatus          sync.PeerSyncStatus
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/van_pending_blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/van_pending_blocks.go
@@ -27,6 +27,7 @@ func (bs *Server) StreamNewPendingBlocks(
 		fSlot, err := helpers.StartSlot(fEpoch + 1)
 
 		if highestFinalizedEpoch > fEpoch {
+			fEpoch = highestFinalizedEpoch
 			fSlot, err = helpers.StartSlot(highestFinalizedEpoch + 1)
 		}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/van_pending_blocks_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/van_pending_blocks_test.go
@@ -7,6 +7,7 @@ import (
 	chainMock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
@@ -43,6 +44,9 @@ func TestServer_StreamNewPendingBlocks_ContextCanceled(t *testing.T) {
 		StateNotifier: chainService.StateNotifier(),
 		BlockNotifier: chainService.BlockNotifier(),
 		BeaconDB:      db,
+		SyncStatus: &mockSync.Sync{
+			IsSyncing: true,
+		},
 	}
 
 	exitRoutine := make(chan bool)
@@ -96,7 +100,11 @@ func TestServer_StreamNewPendingBlocks_PublishBlocks(t *testing.T) {
 		StateNotifier: chainService.StateNotifier(),
 		BlockNotifier: chainService.BlockNotifier(),
 		FinalizationFetcher: &chainMock.ChainService{
-			FinalizedCheckPoint: s.FinalizedCheckpoint()},
+			FinalizedCheckPoint: s.FinalizedCheckpoint(),
+		},
+		SyncStatus: &mockSync.Sync{
+			IsSyncing: true,
+		},
 	}
 
 	exitRoutine := make(chan bool)

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -113,6 +113,7 @@ type Config struct {
 
 	// Vanguard un-confirmed cached block fetcher
 	PendingQueueFetcher blockchain.PendingQueueFetcher
+	SyncStatus          chainSync.PeerSyncStatus
 }
 
 // NewService instantiates a new RPC service instance that will
@@ -258,6 +259,7 @@ func (s *Service) Start() {
 		ReceivedAttestationsBuffer:  make(chan *ethpbv1alpha1.Attestation, attestationBufferSize),
 		CollectedAttestationsBuffer: make(chan []*ethpbv1alpha1.Attestation, attestationBufferSize),
 		PendingQueueFetcher:         s.pendingQueueFetcher,
+		SyncStatus:                  s.cfg.SyncStatus,
 	}
 	beaconChainServerV1 := &beacon.Server{
 		BeaconDB:           s.cfg.BeaconDB,

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -5,6 +5,7 @@ package initialsync
 
 import (
 	"context"
+	types "github.com/prysmaticlabs/eth2-types"
 	"time"
 
 	"github.com/paulbellamy/ratecounter"
@@ -168,6 +169,11 @@ func (s *Service) Resync() error {
 	}
 	log.WithField("slot", s.cfg.Chain.HeadSlot()).Info("Resync attempt complete")
 	return nil
+}
+
+// HighestFinalizedEpoch returns current finalized epoch of its connected peer
+func (s *Service) HighestFinalizedEpoch() types.Epoch {
+	return s.highestFinalizedEpoch()
 }
 
 func (s *Service) waitForMinimumPeers() {

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -163,6 +163,12 @@ func (s *Service) Resync() error {
 	defer func() { s.synced.Set() }() // Reset it at the end of the method.
 	genesis := time.Unix(int64(headState.GenesisTime()), 0)
 
+	// Vanguard: Deactivating verification from orchestrator client
+	if s.cfg.EnableVanguardNode {
+		log.Info("Deactivating orchestrator verification in re-sync mode")
+		s.cfg.Chain.DeactivateOrcVerification()
+	}
+
 	s.waitForMinimumPeers()
 	if err = s.roundRobinSync(genesis); err != nil {
 		log = log.WithError(err)

--- a/beacon-chain/sync/initial-sync/testing/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/testing/BUILD.bazel
@@ -9,4 +9,7 @@ go_library(
         "//beacon-chain:__subpackages__",
         "//fuzz:__pkg__",
     ],
+    deps = [
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
+    ],
 )

--- a/beacon-chain/sync/initial-sync/testing/mock.go
+++ b/beacon-chain/sync/initial-sync/testing/mock.go
@@ -2,6 +2,8 @@
 // sync status in unit tests.
 package testing
 
+import types "github.com/prysmaticlabs/eth2-types"
+
 // Sync defines a mock for the sync service.
 type Sync struct {
 	IsSyncing     bool
@@ -32,4 +34,8 @@ func (s *Sync) Resync() error {
 // Synced --
 func (s *Sync) Synced() bool {
 	return s.IsSynced
+}
+
+func (s *Sync) HighestFinalizedEpoch() types.Epoch {
+	return types.Epoch(0)
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -6,6 +6,7 @@ package sync
 
 import (
 	"context"
+	types "github.com/prysmaticlabs/eth2-types"
 	"sync"
 	"time"
 
@@ -289,4 +290,8 @@ type Checker interface {
 	Synced() bool
 	Status() error
 	Resync() error
+}
+
+type PeerSyncStatus interface {
+	HighestFinalizedEpoch() types.Epoch
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
Restore the orchestrator verification enable/disable code in verification process. Now orchestrator verification will be off during initial sync process and re-sync mode.

And there is an another change in `StreamNewPendingBlocks` api, right now this api sends finalized epoch and slot based on network and its local.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
